### PR TITLE
Remove WaitForJob in GrinConeect

### DIFF
--- a/src/Theta/GrinConeect.cs
+++ b/src/Theta/GrinConeect.cs
@@ -37,7 +37,6 @@ namespace Theta
         public JobTemplate CurrentJob = null;
 
         public DateTime lastComm = DateTime.Now;
-        public volatile bool WaitForJob = false;
         public int BadPacketCnt = 0;
 
         public GrinConeeect(string ip, int port)
@@ -160,8 +159,7 @@ namespace Theta
                         switch (method)
                         {
                             case "job":
-                                 CurrentJob = JsonConvert.DeserializeObject<JobTemplate>(para, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
-                                WaitForJob = false;
+                                CurrentJob = JsonConvert.DeserializeObject<JobTemplate>(para, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
                                 lastComm = DateTime.Now;
                                 break;
                             case "submit":

--- a/src/Theta/Program.cs
+++ b/src/Theta/Program.cs
@@ -160,13 +160,6 @@ namespace Theta
                         //for (ulong i = 0; i < reps; i++)
                         while (!Canceled && gc.IsConnected)
                         {
-                            if (gc.WaitForJob)
-                            {
-                                Task.Delay(100).Wait();
-                                Console.Write(".");
-                                continue;
-                            }
-
                             DateTime a = DateTime.Now;
 
                             GetSols();
@@ -475,8 +468,6 @@ namespace Theta
                                     Console.ResetColor();
 
                                     Task.Run(() => { gc.SendSolution(ActiveSolution, sols); });
-
-                                    gc.WaitForJob = true;
                                 }
                                 else if ((ulong)gc.CurrentJob.height == ActiveSolution.height)
                                 {


### PR DESCRIPTION
Miner will no longer wait for a new job after submitting a solution. Resolves #5 