### PR TITLE
minor fix: suppress the boring warning messages on building

### DIFF
--- a/src/Theta/Blake2B.cs
+++ b/src/Theta/Blake2B.cs
@@ -120,7 +120,7 @@ namespace Crypto
 			var c = new ulong[8];
 
 			// digest length
-			c[0] |= (ulong)HashSizeInBytes;
+			c[0] |= (uint)HashSizeInBytes;
 
 			// Key length
 			if (Key != null)

--- a/src/Theta/Program.cs
+++ b/src/Theta/Program.cs
@@ -206,7 +206,7 @@ namespace Theta
                             dif = (UInt64)gc.CurrentJob.difficulty;
                             header = gc.CurrentJob.GetHeader();
 
-                            UInt64 hnonce = (UInt64)rnd.Next() | ((UInt64)rnd.Next() << 32);
+                            UInt64 hnonce = (UInt64)(long)rnd.Next() | ((UInt64)(long)rnd.Next() << 32);
                             var bytes = BitConverter.GetBytes(hnonce).Reverse().ToArray();
                             //Array.Copy(bytes, 0, header, header.Length - 8, 8);
                             header = header.Concat(bytes).ToArray();
@@ -590,7 +590,7 @@ namespace Theta
 
     public class CGraph
     {
-        const bool ShowCycles = false;
+        private bool ShowCycles = false;
 
         public Dictionary<uint, uint> graphU;
         public Dictionary<uint, uint> graphV;
@@ -626,7 +626,7 @@ namespace Theta
 
         internal void FindSolutions(int cyclen, Queue<Solution> solutions)
         {
-            int dupes = 0;
+            //int dupes = 0;
 
             foreach (var e in edges)
             {


### PR DESCRIPTION

Blake2B.cs(123,4): warning CS0675: Bitwise-or operator used on a sign-extended operand; consider casting to a smaller unsigned type first [src/Theta/Theta.csproj]
Program.cs(637,29): warning CS0162: Unreachable code detected [/home/miner/GrinGoldMiner/src/Theta/Theta.csproj]
Program.cs(644,29): warning CS0162: Unreachable code detected [/home/miner/GrinGoldMiner/src/Theta/Theta.csproj]
Program.cs(674,33): warning CS0162: Unreachable code detected [/home/miner/GrinGoldMiner/src/Theta/Theta.csproj]
Program.cs(629,17): warning CS0219: The variable 'dupes' is assigned but its value is never used [/home/miner/GrinGoldMiner/src/Theta/Theta.csproj]
Program.cs(209,45): warning CS0675: Bitwise-or operator used on a sign-extended operand; consider casting to a smaller unsigned type first [src/Theta/Theta.csproj]
